### PR TITLE
Horizon image from DockerHub

### DIFF
--- a/opennms-har-demo/Dockerfile
+++ b/opennms-har-demo/Dockerfile
@@ -4,7 +4,7 @@
 ##
 
 ARG BASE_IMAGE="opennms/horizon"
-ARG BASE_IMAGE_VERSION="jira_NMS-13190"
+ARG BASE_IMAGE_VERSION="jira-NMS-13190"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as horizon-base
 
@@ -29,10 +29,3 @@ RUN curl --retry 5 --fail -L ${GECKODRIVER_URL} --create-dirs -o /opt/geckodrive
 
 ### Containers should NOT run as root as a good practice - use opennms user for runs
 USER 10001
-
-
-
-
-
-
-

--- a/opennms-har-demo/README.MD
+++ b/opennms-har-demo/README.MD
@@ -6,6 +6,14 @@ I have not changed the OpenNMS opennms-container within this branch but have pro
 
 check out branch jira/NMS-13190 (https://github.com/OpenNMS/opennms/tree/jira/NMS-13190)
 
+If you want to use the latest build from jira/NMS-13190, you can pull the container image from DockerHub with
+
+```
+docker pull opennms/horizon:jira-NMS-13190
+```
+
+You can skip step 1 and 2.
+
 1. compile opennms
 
 In opennms folder, compile as normal using
@@ -19,7 +27,7 @@ This will build opennms and create a tarball of opennms in opennms/target.
 
 To simply build a docker image of this tarball, run the simple-horizon-image-build.sh script in the folder above (parent) of your checked out opennms. 
 
-This will create a docker image of opennms tagged opennms/horizon:jira_NMS-13190 which can be used for the next step.
+This will create a docker image of opennms tagged opennms/horizon:jira-NMS-13190 which can be used for the next step.
 
 3. create image with horizon  horizon, headless firefox and selenium driver
 

--- a/opennms-har-demo/docker-compose.yaml
+++ b/opennms-har-demo/docker-compose.yaml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   database:
-    image: ${DOCKER_REGISTRY:-docker.io}/postgres:${POSTGRES_VERSION:-13}
+    image: postgres:13
     container_name: database
     hostname: database
     environment:
@@ -29,7 +29,7 @@ services:
       retries: 3
 
   cassandra-01:
-    image: ${DOCKER_REGISTRY:-docker.io}/cassandra:${CASSANDRA_VERSION:-3.11}
+    image: cassandra:3.11
     container_name: cassandra-01
     hostname: cassandra-01
     environment:
@@ -81,7 +81,7 @@ services:
       retries: 3
 
   grafana:
-    image: ${DOCKER_REGISTRY:-docker.io}/grafana/grafana:${GRAFANA_VERSION:-7.5.0}
+    image: grafana/grafana:7.5.0
     container_name: grafana
     hostname: grafana
     environment:
@@ -94,7 +94,7 @@ services:
       - "3000:3000/tcp"
       
   es01:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION:-6.8.13}
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.13
     container_name: es01
     hostname: es01
     environment:
@@ -113,7 +113,7 @@ services:
       retries: 5
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:${KIBANA_VERSION:-6.8.13}
+    image: docker.elastic.co/kibana/kibana:6.8.13
     container_name: kibana
     hostname: kibana
     depends_on: 
@@ -128,5 +128,3 @@ services:
       interval: 30s
       timeout: 10s
       retries: 50
-      
-

--- a/opennms-har-demo/simple-horizon-image-build.sh
+++ b/opennms-har-demo/simple-horizon-image-build.sh
@@ -3,7 +3,7 @@
 echo create docker image from opennms tarball. Run this script in the directory above opennms git repository
 
 branch=$(git -C ./opennms branch --show-current)
-name="${branch//'/'/"_"}"
+name="${branch//'/'/"-"}"
 echo creating docker image  $branch  in $name.oci
 
 cp -v opennms/target/*SNAPSHOT.tar.gz  opennms/opennms-container/horizon/tarball/


### PR DESCRIPTION
Updated the Dockerfile for Firefox with HAR support to use the image from DockerHub. Set fixed versions in the
docker-compose.yml to fixed versions to avoid issues during deployment and don't allow overwriting with ENV vars.